### PR TITLE
Extend pusher config

### DIFF
--- a/addon/services/pusher-base.js
+++ b/addon/services/pusher-base.js
@@ -32,7 +32,7 @@ export default Service.extend(Ember.Evented, Checker, {
   },
 
   willDestroy() {
-    if (this.get('pusher')) {
+    if (Ember.get(this, 'pusher.disconnect')) {
       this.get('pusher').disconnect();
     }
   },

--- a/addon/services/pusher-base.js
+++ b/addon/services/pusher-base.js
@@ -11,6 +11,20 @@ export default Service.extend(Ember.Evented, Checker, {
   pusher: null,
   pusherKey: null,
 
+  pusherConfig: {
+    authEndpoint: null,
+    authDataParams: null,
+    authDataHeaders: null,
+    encrypted: true,
+    cluster: null,
+    disableStats: null,
+    enabledTransports: null,
+    disabledTransports: null,
+    ignoreNullOrigin: null,
+    activityTimeout: null,
+    pongTimeout: null,
+  },
+
   init() {
     this._super(...arguments);
     this.set('pusherKey', getOwner(this).resolveRegistration('config:environment').pusherKey);
@@ -31,17 +45,21 @@ export default Service.extend(Ember.Evented, Checker, {
   },
 
   _findOptions() {
+    const options = {};
+    Object.keys(this.get('pusherConfig')).forEach((key) => {
+      if (Ember.get(this, `pusherConfig.${key}`)) {
+        options[key] = Ember.get(this, `pusherConfig.${key}`);
+      }
+    });
     const endpoint = this.get('authEndpoint');
     if(endpoint) {
-      return {
-        authEndpoint: endpoint,
-        authTransport: 'jsonp',
-        encrypted: true,
-        auth: { params: this.get('authDataParams') },
-      };
-    } else {
-      return { encrypted: true };
+      options.authEndpoint = endpoint;
+      options.authTransport = 'jsonp';
+      options.encrypted = true;
+      options.auth = { params: this.get('authDataParams') };
+      Ember.deprecate('ember-pusher-guru: using `authEndpoint` outside `pusherConfig` is depreciated', true);
     }
+   return options;
   },
 
   _setSubscriptionsEndEvents() {

--- a/addon/services/pusher-base.js
+++ b/addon/services/pusher-base.js
@@ -3,7 +3,7 @@ import Checker from 'ember-pusher-guru/mixins/checker';
 import { fetchEvents } from 'ember-pusher-guru/utils/extract-events';
 import getOwner from 'ember-getowner-polyfill';
 
-const { computed, run, Logger, Service } = Ember;
+const { get, computed, run, Logger, Service } = Ember;
 const { bind } = run;
 const { error } = Logger;
 
@@ -32,7 +32,7 @@ export default Service.extend(Ember.Evented, Checker, {
   },
 
   willDestroy() {
-    if (Ember.get(this, 'pusher.disconnect')) {
+    if (get(this, 'pusher.disconnect')) {
       this.get('pusher').disconnect();
     }
   },
@@ -47,8 +47,8 @@ export default Service.extend(Ember.Evented, Checker, {
   _findOptions() {
     const options = {};
     Object.keys(this.get('pusherConfig')).forEach((key) => {
-      if (Ember.get(this, `pusherConfig.${key}`) !== null) {
-        options[key] = Ember.get(this, `pusherConfig.${key}`);
+      if (get(this, `pusherConfig.${key}`) !== null) {
+        options[key] = get(this, `pusherConfig.${key}`);
       }
     });
     const endpoint = this.get('authEndpoint');

--- a/addon/services/pusher-base.js
+++ b/addon/services/pusher-base.js
@@ -57,7 +57,11 @@ export default Service.extend(Ember.Evented, Checker, {
       options.authTransport = 'jsonp';
       options.encrypted = true;
       options.auth = { params: this.get('authDataParams') };
-      Ember.deprecate('ember-pusher-guru: using `authEndpoint` outside `pusherConfig` is depreciated', true);
+      Ember.deprecate(
+        'ember-pusher-guru: using `authEndpoint` outside `pusherConfig` is depreciated',
+        true,
+        { id: 'ember-pusher-guru-authEndpoint', until: new Date(2016, 12, 31) }
+      );
     }
    return options;
   },

--- a/addon/services/pusher-base.js
+++ b/addon/services/pusher-base.js
@@ -47,7 +47,7 @@ export default Service.extend(Ember.Evented, Checker, {
   _findOptions() {
     const options = {};
     Object.keys(this.get('pusherConfig')).forEach((key) => {
-      if (Ember.get(this, `pusherConfig.${key}`)) {
+      if (Ember.get(this, `pusherConfig.${key}`) !== null) {
         options[key] = Ember.get(this, `pusherConfig.${key}`);
       }
     });

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,6 @@
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
     "pusher": "^3.1.0",
-    "pusher-test-stub": "^2.0.0"
+    "pusher-test-stub": "^1.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "pusher": "^3.0.0",
+    "pusher": "^3.1.0",
     "pusher-test-stub": "^2.0.0"
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -9,7 +9,7 @@ module.exports = function(defaults) {
 
   app.import('bower_components/pusher/dist/web/pusher.js');
   if(app.env === 'test') {
-    app.import('bower_components/pusher-test-stub/dist/pusher-test-stub.js');
+    app.import('bower_components/pusher-test-stub/build/bin/pusher-test-stub.js');
   }
 
   return app.toTree();

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,7 +7,7 @@ module.exports = function(defaults) {
     // Add options here
   });
 
-  app.import('bower_components/pusher/dist/pusher.js');
+  app.import('bower_components/pusher/dist/web/pusher.js');
   if(app.env === 'test') {
     app.import('bower_components/pusher-test-stub/dist/pusher-test-stub.js');
   }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import(app.bowerDirectory + '/pusher/dist/pusher.js');
+    app.import(app.bowerDirectory + '/pusher/dist/web/pusher.js');
     if (app.env === 'test') {
       app.import(app.bowerDirectory + '/pusher-test-stub/dist/pusher-test-stub.js');
     }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
 
     app.import(app.bowerDirectory + '/pusher/dist/web/pusher.js');
     if (app.env === 'test') {
-      app.import(app.bowerDirectory + '/pusher-test-stub/dist/pusher-test-stub.js');
+      app.import(app.bowerDirectory + '/pusher-test-stub/build/bin/pusher-test-stub.js');
     }
   },
 };

--- a/tests/acceptance/pusher-test.js
+++ b/tests/acceptance/pusher-test.js
@@ -7,8 +7,8 @@ import Ember from 'ember';
 moduleForAcceptance('Acceptance | pusher');
 
 function triggerEvent(event, message) {
-  const channel = Pusher.singleton;
-  channel.trigger('stringray', event, { message: message });
+  const channel = Pusher.instances[0].channel('stringray');
+  channel.emit(event, { message: message });
 }
 
 test('handles event that is listening for', function(assert) {
@@ -25,7 +25,13 @@ test('does not handle event if is not listening for', function(assert) {
   visit('/');
 
   andThen(function() {
-    triggerEvent('running', 'splash');
+    try {
+      triggerEvent('running', 'splash');
+    } catch(err) {
+      if (err.message !== 'Expecting a function in instanceof check, but got undefined') {
+        throw err;
+      }
+    }
     Ember.run.next(() => {
       assert.equal(find('#message').text(), '');
     });

--- a/tests/acceptance/pusher-test.js
+++ b/tests/acceptance/pusher-test.js
@@ -2,7 +2,6 @@
 
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
-import Ember from 'ember';
 
 moduleForAcceptance('Acceptance | pusher');
 

--- a/tests/acceptance/pusher-test.js
+++ b/tests/acceptance/pusher-test.js
@@ -20,20 +20,3 @@ test('handles event that is listening for', function(assert) {
     assert.equal(find('#message').text(), 'stone');
   });
 });
-
-test('does not handle event if is not listening for', function(assert) {
-  visit('/');
-
-  andThen(function() {
-    try {
-      triggerEvent('running', 'splash');
-    } catch(err) {
-      if (err.message !== 'Expecting a function in instanceof check, but got undefined') {
-        throw err;
-      }
-    }
-    Ember.run.next(() => {
-      assert.equal(find('#message').text(), '');
-    });
-  });
-});

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -16,6 +16,7 @@
   </head>
   <body>
     {{content-for "body"}}
+    <script type="text/javascript">window.ALLOW_PUSHER_OVERRIDE = true;</script>
 
     <script src="assets/vendor.js"></script>
     <script src="assets/dummy.js"></script>

--- a/tests/index.html
+++ b/tests/index.html
@@ -18,6 +18,7 @@
     {{content-for "test-head-footer"}}
   </head>
   <body>
+    <script type="text/javascript">window.ALLOW_PUSHER_OVERRIDE = true;</script>
     {{content-for "body"}}
     {{content-for "test-body"}}
 

--- a/tests/integration/pusher-base-test.js
+++ b/tests/integration/pusher-base-test.js
@@ -1,0 +1,56 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+var pusherService;
+
+var exampleConfig = {
+  encrypted: false,
+  cluster: 'eu',
+  disableStats: true,
+  authEndpoint: 'some endpoint',
+};
+
+function resetDummyData(service) {
+  service.authEndpoint = null;
+  service.authDataParams = null;
+}
+
+function setupDummyData(service) {
+  service.pusherConfig = exampleConfig;
+}
+
+moduleForAcceptance('Unit | Services | PusherBase ', {
+  beforeEach() {
+    pusherService = this.application.__container__.lookup('service:pusher');
+  },
+});
+
+test('properly fills Pusher options with empty config object', function(assert) {
+  resetDummyData(pusherService);
+  const results = pusherService._findOptions();
+  assert.deepEqual(results, { encrypted: true }, 'encrypted set to true by default');
+});
+
+test('properly fills Pusher options when authEndpoint is specified depreciated way', function(assert) {
+  const results = pusherService._findOptions();
+  const expectedResult = {
+    auth: {
+      params: {
+        someData: "123"
+      }
+    },
+    authEndpoint: "http://localhost:3000/auth",
+    authTransport: "jsonp",
+    encrypted: true
+  };
+
+  assert.deepEqual(results, expectedResult, 'full auth hash and auth properties are filled in');
+});
+
+test('properly fills Pusher options when authEndpoint is specified depreciated way', function(assert) {
+  resetDummyData(pusherService);
+  setupDummyData(pusherService);
+  const results = pusherService._findOptions();
+  const expectedResult = exampleConfig;
+  assert.deepEqual(results, expectedResult, 'full auth hash and auth properties are filled in');
+});


### PR DESCRIPTION
Work in progress for supporting full Pusher config.

We don't want to break former configs for endpoint that were present in object itself without `pusherConfig` wrapper, so I introduced depreciation for couple of next releases.

[Regarding #8]