### PR TITLE
Enable updating of channelsData dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ contentSecurityPolicy: {
 }
 ```
 
+Then you need to add this line:
+```html
+<script type="text/javascript">window.ALLOW_PUSHER_OVERRIDE = true;</script>
+```
+to your `tests/index.html` right after the `body` tag. This will allow `pusher-test-stub` to work and run your tests.
+
 ## Usage
 
 You need to create service which must be extended from `pusher-base` service:

--- a/addon/services/pusher-base.js
+++ b/addon/services/pusher-base.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 import Checker from 'ember-pusher-guru/mixins/checker';
 import { fetchEvents } from 'ember-pusher-guru/utils/extract-events';
-import { channelsDiff } from 'ember-pusher-guru/utils/channels-diff';
+import { channelsDiff, removeChannel } from 'ember-pusher-guru/utils/channels-diff';
 import getOwner from 'ember-getowner-polyfill';
 
-const { get, computed, run, Logger, Service } = Ember;
+const { get, computed, run, Logger, Service, isArray } = Ember;
 const { bind } = run;
 const { error } = Logger;
 
@@ -48,7 +48,24 @@ export default Service.extend(Ember.Evented, Checker, {
   },
 
   updateChannelsData(newChannelsData) {
+    this._checkDataStructure(newChannelsData);
     this._manageChannelsChange(this.get('channelsData'), newChannelsData);
+  },
+
+  removeChannel(channelName) {
+    this._manageChannelsChange(
+      this.get('channelsData'),
+      removeChannel(this.get('channelsData'), channelName)
+    );
+  },
+
+  addChannelsData(newChannelsData) {
+    const channelData = this.get('channelsData');
+    this._checkDataStructure(newChannelsData);
+    const updatedChannelsData = isArray(newChannelsData) ?
+      [...channelData, ...newChannelsData] :
+      [...channelData, newChannelsData];
+    this._manageChannelsChange(channelData, updatedChannelsData);
   },
 
   _findOptions() {

--- a/addon/utils/channels-diff.js
+++ b/addon/utils/channels-diff.js
@@ -1,4 +1,4 @@
-function channelIncluded(channelData, channelsList) {
+function channelNotIncluded(channelData, channelsList) {
   const [channelName] = Object.keys(channelData);
   return channelsList.indexOf(channelName) < 0;
 }
@@ -13,9 +13,9 @@ export function channelsDiff(oldChannelsData, newChannelsData) {
   const oldChannels = oldChannelsData.map(channel => Object.keys(channel)[0]);
   const newChannels = newChannelsData.map(channel => Object.keys(channel)[0]);
   const channelsToUnsubscribe = oldChannelsData
-    .filter((channel) => channelIncluded(channel, newChannels));
+    .filter((channel) => channelNotIncluded(channel, newChannels));
   const channelsToSubscribe = newChannelsData
-    .filter((channel) => channelIncluded(channel, oldChannels));
+    .filter((channel) => channelNotIncluded(channel, oldChannels));
 
   return { channelsToUnsubscribe, channelsToSubscribe };
 }

--- a/addon/utils/channels-diff.js
+++ b/addon/utils/channels-diff.js
@@ -3,6 +3,12 @@ function channelIncluded(channelData, channelsList) {
   return channelsList.indexOf(channelName) < 0;
 }
 
+export function removeChannel(channelsData, channelName) {
+  return channelsData.filter((channel) => {
+    return Object.keys(channel)[0] !== channelName;
+  });
+}
+
 export function channelsDiff(oldChannelsData, newChannelsData) {
   const oldChannels = oldChannelsData.map(channel => Object.keys(channel)[0]);
   const newChannels = newChannelsData.map(channel => Object.keys(channel)[0]);

--- a/addon/utils/channels-diff.js
+++ b/addon/utils/channels-diff.js
@@ -1,0 +1,15 @@
+function channelIncluded(channelData, channelsList) {
+  const [channelName] = Object.keys(channelData);
+  return channelsList.indexOf(channelName) < 0;
+}
+
+export function channelsDiff(oldChannelsData, newChannelsData) {
+  const oldChannels = oldChannelsData.map(channel => Object.keys(channel)[0]);
+  const newChannels = newChannelsData.map(channel => Object.keys(channel)[0]);
+  const channelsToUnsubscribe = oldChannelsData
+    .filter((channel) => channelIncluded(channel, newChannels));
+  const channelsToSubscribe = newChannelsData
+    .filter((channel) => channelIncluded(channel, oldChannels));
+
+  return { channelsToUnsubscribe, channelsToSubscribe };
+}

--- a/app/utils/channel-diff.js
+++ b/app/utils/channel-diff.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-pusher-guru/utils/channels-diff';

--- a/blueprints/ember-pusher-guru/index.js
+++ b/blueprints/ember-pusher-guru/index.js
@@ -4,8 +4,8 @@ module.exports = {
   afterInstall: function() {
     var blueprint = this;
 
-    return blueprint.addBowerPackageToProject('pusher', '3.0.0').then(function() {
-      return blueprint.addBowerPackageToProject('pusher-test-stub', '2.0.0');
+    return blueprint.addBowerPackageToProject('pusher', '3.1.0').then(function() {
+      return blueprint.addBowerPackageToProject('pusher-test-stub', '1.0.0');
     });
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "pusher": "^3.1.0",
+    "pusher": "3.1.0",
     "pusher-test-stub": "^1.0.0"
   }
 }

--- a/tests/acceptance/pusher-test.js
+++ b/tests/acceptance/pusher-test.js
@@ -1,21 +1,26 @@
 /*global Pusher:true*/
-
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | pusher');
 
-function triggerEvent(event, message) {
-  const channel = Pusher.instances[0].channel('stringray');
+function triggerEvent(event, message, channelName = 'stringray') {
+  const channel = Pusher.instances[0].channel(channelName);
   channel.emit(event, { message: message });
 }
 
 test('handles event that is listening for', function(assert) {
   visit('/');
-
-  andThen(function() {
+  andThen(() => {
     assert.equal(currentURL(), '/');
     triggerEvent('cover', 'stone');
     assert.equal(find('#message').text(), 'stone');
+    triggerEvent('new_event', 'New event', 'new_channel');
+    assert.equal(
+      find('#message').text(),
+      'New event',
+      'it handles dynamically added events'
+    );
   });
 });
+

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -2,14 +2,24 @@
 import Ember from 'ember';
 import PusherInitializer from 'ember-pusher-guru/mixins/pusher-initializer';
 
-const { Route } = Ember;
+const { Route, inject: { service } } = Ember;
 
 export default Route.extend(PusherInitializer, {
+  pusher: service(),
+  message: null,
   pusherActions: [
     { swim: 'handleSwim' },
     { cover: 'handleCover' },
-    { electroshock: 'handleElectroshock' }
+    { electroshock: 'handleElectroshock' },
+    { new_event: 'handleNewEvent' }
   ],
+
+  init() {
+    this._super(...arguments);
+    this.get('pusher').addChannelsData(
+      { new_channel: ['new_event'] }
+    );
+  },
 
   handleCover(data) {
     Ember.$('#message').text(data.message);
@@ -18,6 +28,9 @@ export default Route.extend(PusherInitializer, {
     Ember.$('#message').text(data.message);
   },
   handleSwim(data) {
+    Ember.$('#message').text(data.message);
+  },
+  handleNewEvent(data) {
     Ember.$('#message').text(data.message);
   },
 

--- a/tests/dummy/app/services/pusher.js
+++ b/tests/dummy/app/services/pusher.js
@@ -23,4 +23,8 @@ export default PusherBase.extend({
     // some dynamic authorization data that may be based on e.g. current user token
     return { someData: '123' };
   }),
+
+  init() {
+    this._super(...arguments);
+  }
 });

--- a/tests/integration/pusher-base-test.js
+++ b/tests/integration/pusher-base-test.js
@@ -101,3 +101,49 @@ test('it changes the channels list instead of only adding to it', function(asser
   const registeredChannels = Object.keys(pusherService.pusher._channels);
   assert.deepEqual(registeredChannels, ['new_channel']);
 });
+
+test('it removes and unsubscribes from channels when removeChannel called', function(assert) {
+  setupDummyData(pusherService);
+  const channelsData = [
+    { my_channel: ['test_data'] },
+    { test_channel: ['test_event'] }
+  ];
+  pusherService.set('channelsData', channelsData);
+  pusherService.setup();
+  stubUnsubscribe(pusherService.get('pusher'));
+  pusherService.removeChannel('my_channel');
+  const registeredChannels = Object.keys(pusherService.pusher._channels);
+  assert.deepEqual(registeredChannels, ['test_channel']);
+});
+
+test(
+  'it adds and subscribes to channels with addChannelsData (object form)',
+  function(assert) {
+    setupDummyData(pusherService);
+    const channelsData = [
+      { test_channel: ['test_event'] }
+    ];
+    pusherService.set('channelsData', channelsData);
+    pusherService.setup();
+    stubUnsubscribe(pusherService.get('pusher'));
+    pusherService.addChannelsData({ my_channel: ['test_data'] });
+    const registeredChannels = Object.keys(pusherService.pusher._channels);
+    assert.deepEqual(registeredChannels, ['test_channel', 'my_channel']);
+  }
+);
+
+test(
+  'it adds and subscribes to channels with addChannelsData (array form)',
+  function(assert) {
+    setupDummyData(pusherService);
+    const channelsData = [
+      { test_channel: ['test_event'] }
+    ];
+    pusherService.set('channelsData', channelsData);
+    pusherService.setup();
+    stubUnsubscribe(pusherService.get('pusher'));
+    pusherService.addChannelsData([{ my_channel: ['test_data'] }]);
+    const registeredChannels = Object.keys(pusherService.pusher._channels);
+    assert.deepEqual(registeredChannels, ['test_channel', 'my_channel']);
+  }
+ );

--- a/tests/unit/channels-diff-test.js
+++ b/tests/unit/channels-diff-test.js
@@ -1,0 +1,43 @@
+import { channelsDiff } from 'ember-pusher-guru/utils/channels-diff';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | channelsDiff');
+
+test('it properly replaces channels', function(assert) {
+  const oldChannelsData = [{ test_channel: ['test_event'] }];
+  const newChannelsData = [{ new_channel: ['new_event'] }];
+  const diff = channelsDiff(oldChannelsData, newChannelsData);
+  assert.deepEqual(diff.channelsToSubscribe, newChannelsData);
+  assert.deepEqual(diff.channelsToUnsubscribe, oldChannelsData);
+});
+
+test('it properly replaces channels when some of them repeat', function(assert) {
+  const oldChannelsData = [{ test_channel: ['test_event'] }];
+  const newChannelsData = [ ...oldChannelsData, { new_channel: ['new_event'] }];
+  const diff = channelsDiff(oldChannelsData, newChannelsData);
+  assert.deepEqual(diff.channelsToUnsubscribe, []);
+  assert.deepEqual(diff.channelsToSubscribe, [{ new_channel: ['new_event'] }]);
+});
+
+test('it properly diffs when newChannelsData same as old', function(assert) {
+  const oldChannelsData = [{ test_channel: ['test_event'] }];
+  const newChannelsData = [ ...oldChannelsData ];
+  const diff = channelsDiff(oldChannelsData, newChannelsData);
+  assert.deepEqual(diff.channelsToUnsubscribe, []);
+  assert.deepEqual(diff.channelsToSubscribe, []);
+});
+
+test('it properly diffs mixed', function(assert){
+  const oldChannelsData = [{ test_channel: ['test_event'] }];
+  const newChannelsData = [
+    { foo_channel: ['foo_event'] },
+    { new_channel: ['new_event', 'new_event2']}
+  ];
+
+  const diff = channelsDiff(oldChannelsData, newChannelsData);
+  assert.deepEqual(diff.channelsToUnsubscribe, [{ test_channel: ['test_event'] }]);
+  assert.deepEqual(
+    diff.channelsToSubscribe,
+    [{ foo_channel: ['foo_event'] }, { new_channel: ['new_event', 'new_event2'] }]
+  );
+});

--- a/tests/unit/channels-diff-test.js
+++ b/tests/unit/channels-diff-test.js
@@ -1,4 +1,4 @@
-import { channelsDiff } from 'ember-pusher-guru/utils/channels-diff';
+import { channelsDiff, removeChannel } from 'ember-pusher-guru/utils/channels-diff';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | channelsDiff');
@@ -40,4 +40,15 @@ test('it properly diffs mixed', function(assert){
     diff.channelsToSubscribe,
     [{ foo_channel: ['foo_event'] }, { new_channel: ['new_event', 'new_event2'] }]
   );
+});
+
+test('it properly removes channel', function(assert) {
+  const channelsData = [
+    { test_channel: ['test_event'] },
+    { my_channel: ['my_event'] }
+  ];
+
+  const newChannelsData = removeChannel(channelsData, 'my_channel');
+
+  assert.deepEqual(newChannelsData, [{ test_channel: ['test_event'] }]);
 });


### PR DESCRIPTION
This PR adds the functionality of dynamically updating `channelsData` property. It exposes three new functions:
- `updateChannelsData` - replaces existing channelsData with the one provided
- `addChannelsData` - adds single or (if argument is array) multiple channel data
- `removeChannel` - removes specified channel

Closes #10 