### PR TITLE
Add dynamic handling of events

### DIFF
--- a/addon/mixins/pusher-initializer.js
+++ b/addon/mixins/pusher-initializer.js
@@ -18,6 +18,8 @@ export default Ember.Mixin.create({
     const method = this._getEventMethodName(event);
     if (this[method] && this[method].apply) {
       this[method](data);
+    } else {
+      this.onPusherAction(event, data);
     }
   },
 

--- a/tests/acceptance/pusher-test.js
+++ b/tests/acceptance/pusher-test.js
@@ -21,6 +21,12 @@ test('handles event that is listening for', function(assert) {
       'New event',
       'it handles dynamically added events'
     );
+    triggerEvent('dynamic_event', 'New event', 'dynamic_channel');
+    assert.equal(
+      find('#message').text(),
+      'Event: dynamic_event | Message: New event',
+      'it handles events without declared subscription'
+    );
   });
 });
 

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -14,6 +14,10 @@ export default Route.extend(PusherInitializer, {
     { new_event: 'handleNewEvent' }
   ],
 
+  onPusherAction(event, data) {
+    Ember.$('#message').text(`Event: ${event} | Message: ${data.message}`);
+  },
+
   init() {
     this._super(...arguments);
     this.get('pusher').addChannelsData(

--- a/tests/dummy/app/services/pusher.js
+++ b/tests/dummy/app/services/pusher.js
@@ -15,7 +15,8 @@ export default PusherBase.extend({
     return [
       firstChannel,
       { eel: ['electroshock', 'swim'] },
-      { 'private-coconut': ['fall'] }
+      { 'private-coconut': ['fall'] },
+      { dynamic_channel: ['dynamic_event'] }
     ];
   }),
 


### PR DESCRIPTION
This PR adds a possibility for handling events without declaring them. This means in the route you can now do:
```js
export default Route.extend({
  onPusherAction(event, data) {
    // add handling for custom events
  }
});
```
and it will handle all actions that were not specifically declared before.