### PR TITLE
configurable autoConnect

### DIFF
--- a/addon/services/pusher-base.js
+++ b/addon/services/pusher-base.js
@@ -11,6 +11,7 @@ const { error } = Logger;
 export default Service.extend(Ember.Evented, Checker, {
   pusher: null,
   pusherKey: null,
+  autoConnect: true,
 
   pusherConfig: {
     authEndpoint: null,
@@ -29,7 +30,9 @@ export default Service.extend(Ember.Evented, Checker, {
   init() {
     this._super(...arguments);
     this.set('pusherKey', getOwner(this).resolveRegistration('config:environment').pusherKey);
-    this.setup();
+    if(this.get('autoConnect')) {
+      this.setup();
+    }
   },
 
   willDestroy() {

--- a/tests/integration/pusher-base-test.js
+++ b/tests/integration/pusher-base-test.js
@@ -1,6 +1,8 @@
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
+import PusherBase from 'ember-pusher-guru/services/pusher-base';
+
 var pusherService;
 
 var exampleConfig = {
@@ -147,3 +149,26 @@ test(
     assert.deepEqual(registeredChannels, ['test_channel', 'my_channel']);
   }
  );
+
+test('it auto-connects by default', function(assert) {
+  var derivedPusherService = PusherBase.extend({
+    setup() {
+      this.set('setupWasCalled', true);
+    }
+  });
+  this.application.register('service:my-pusher', derivedPusherService);
+  var derivedServiceInstance = this.application.__container__.lookup('service:my-pusher');
+  assert.ok(derivedServiceInstance.get('setupWasCalled'));
+});
+
+test('it can be configured not to auto-connect', function(assert) {
+  var derivedPusherService = PusherBase.extend({
+    autoConnect: false,
+    setup() {
+      this.set('setupWasCalled', true);
+    }
+  });
+  this.application.register('service:my-pusher', derivedPusherService);
+  var derivedServiceInstance = this.application.__container__.lookup('service:my-pusher');
+  assert.notOk(derivedServiceInstance.get('setupWasCalled'));
+});


### PR DESCRIPTION
This adds an optional `autoConnect` property to the base pusher service, so derived services can opt out. (addressing issue https://github.com/netguru/ember-pusher-guru/issues/17)